### PR TITLE
Prohibit pages flipping by user in RootVC

### DIFF
--- a/MarvelPedia/RootVC.swift
+++ b/MarvelPedia/RootVC.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class RootVC: UIViewController, UIPageViewControllerDelegate {
     
-    var pageViewController: UIPageViewController?
+    var pageViewController: UIPageViewController!
     var pageFlipTimer: NSTimer?
     
     var characters = [Character]()
@@ -20,6 +20,13 @@ class RootVC: UIViewController, UIPageViewControllerDelegate {
         // Do any additional setup after loading the view, typically from a nib.
         // Configure the page view controller and add it as a child view controller.
         self.pageViewController = UIPageViewController(transitionStyle: .PageCurl, navigationOrientation: .Horizontal, options: nil)
+        
+        // Prohibit pages flipping by user
+        for recognizer in self.pageViewController.gestureRecognizers {
+            if let recognizer = recognizer as? UIGestureRecognizer {
+                recognizer.enabled = false
+            }
+        }
         self.pageViewController!.delegate = self
         
         let startingViewController: IntroPageVC = self.modelController.viewControllerAtIndex(0, storyboard: self.storyboard!)!


### PR DESCRIPTION
I've found a bug in the rootVC. A user can interrupt page flipping animations by trying to flip pages manually. Needed to remove all gesture recognizers from UIPageViewController instance.
